### PR TITLE
Name the autoloaded commands without the shorthand

### DIFF
--- a/beardbolt.el
+++ b/beardbolt.el
@@ -651,7 +651,7 @@ determine LANG from `major-mode'."
     ("rust" . "beardbolt.rs")))
 
 ;;;###autoload
-(defun bb-starter (lang-name)
+(defun beardbolt-starter (lang-name)
   "Setup new sandbox file for experiments.
 With prefix argument, choose from starter files in `bb-starter-files'."
   (interactive
@@ -763,7 +763,7 @@ With prefix argument, choose from starter files in `bb-starter-files'."
       (list cmd bb-ccj-extra-flags)))
 
 ;;;###autoload
-(define-minor-mode bb-mode
+(define-minor-mode beardbolt-mode
   "Toggle `beardbolt-mode'.  May be enabled by user in source buffer."
   :global nil :lighter " ⚡" :keymap bb-mode-map
   (cond


### PR DESCRIPTION
First, I would like to thank you for this package (and the others)!

This is a small change that rename the autoloaded commands.

In Emacs (at least, when using `straight.el`), the autoload file don't take the shorthand into account. This causes Emacs to declare `bb-starter` instead of `beardbolt-starter`. This also causes `bb-mode` to interfere with other mode with the same name `bitbake-mode`.

I've seen that in your other package, you are avoiding the shorthand in the autoloaded commands:

https://github.com/joaotavora/breadcrumb/blob/dcb6e2e82de2432d8eb75be74c8d6215fc97a2d3/breadcrumb.el#L413-L415

So I think this MR make sense!

Thanks again!