### PR TITLE
Close #5: Quote buffer filename for compile command

### DIFF
--- a/beardbolt.el
+++ b/beardbolt.el
@@ -223,7 +223,7 @@ Useful if you have multiple objdumpers and want to select between them")
                                     "-o" ,out
                                     ,@(if modified-p
                                           `("-x" ,language "-" "<" ,in)
-                                        `(,(buffer-file-name)))))
+                                        `(,(shell-quote-argument (buffer-file-name))))))
                 (assemble (in out) `("&&" ,cc "-c" ,in "-o" ,out))
                 (link     (in out) `("&&" ,cc ,in      "-fsanitize=address" "-o" ,out))
                 (execute  (in)     `("&& (" ,in


### PR DESCRIPTION
Fixes #5.

Tested manually with and without `beardbolt-disassemble`.

```
M-x beardbolt-mode

*Messages* Beardbolt mode enabled in current buffer

M-; (setq beardbolt-disassemble nil)
M-x beardbolt-compile

*Messages* Wrote /tmp/beardbolt-dump-Eh5t0s.cc
*Messages* Compilation finished

M-; (setq beardbolt-disassemble t)
M-x beardbolt-compile

*Messages* Wrote /tmp/beardbolt-dump-yfrTD4.cc
*Messages* Compilation finished
```